### PR TITLE
Fix/mising kafka oauth library e2e

### DIFF
--- a/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
+++ b/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
@@ -20,7 +20,7 @@ import requests
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.admin import (NewTopic, NewPartitions, KafkaAdminClient, ACL, ACLFilter, ResourceType,
                          ACLOperation, ACLPermissionType, ResourcePattern, ConfigResource, ConfigResourceType)
-from kafka.oauth import AbstractTokenProvider
+from kafka.sasl import AbstractTokenProvider
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 

--- a/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
+++ b/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
@@ -20,7 +20,7 @@ import requests
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.admin import (NewTopic, NewPartitions, KafkaAdminClient, ACL, ACLFilter, ResourceType,
                          ACLOperation, ACLPermissionType, ResourcePattern, ConfigResource, ConfigResourceType)
-from kafka.sasl import AbstractTokenProvider
+from kafka.sasl.oauth import AbstractTokenProvider
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After updating the kafka-connect library dependency, integration tests failed with the error kafka.oauth module not found. This error is related to the fact that since version 2.1, kafka.oauth has been renamed to kafka.sasl.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: no need.
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
