### PR TITLE
feat: update docker-entrypoint.sh to support kafkactl context management

### DIFF
--- a/docker-cruise-control/docker/Dockerfile
+++ b/docker-cruise-control/docker/Dockerfile
@@ -44,6 +44,7 @@ FROM eclipse-temurin:21-jdk-alpine-3.23
 RUN mkdir -p /cruise-control
 
 ENV KAFKA_CTL_CONFIG=/cruise-control/kafkactl.yml
+ENV USER=1001
 
 WORKDIR cruise-control
 

--- a/docker-cruise-control/docker/docker-entrypoint.sh
+++ b/docker-cruise-control/docker/docker-entrypoint.sh
@@ -178,8 +178,6 @@ for VAR in `env`; do
 done
 
 if [[ "${EXTERNAL_KAFKA_ENABLED}" == "false" ]]; then
-  # Some static Go binaries need USER set when running under numeric UID.
-  export USER="${USER:-kafka}"
   kafkactl create topic __CruiseControlMetrics --partitions=-1 --replication-factor=-1
 fi
 

--- a/docker-cruise-control/docker/docker-entrypoint.sh
+++ b/docker-cruise-control/docker/docker-entrypoint.sh
@@ -33,7 +33,6 @@ EOL
 
 function prepare_secured_config_files() {
   cat > ${KAFKA_CTL_CONFIG} << EOL
-current-context: default
 contexts:
   default:
     brokers: [${BOOTSTRAP_SERVERS}]
@@ -47,7 +46,6 @@ EOL
 
 function prepare_unsecured_config_files() {
   cat > ${KAFKA_CTL_CONFIG} << EOL
-current-context: default
 contexts:
   default:
     brokers: [${BOOTSTRAP_SERVERS}]
@@ -87,6 +85,10 @@ if [[ -n ${KAFKA_AUTH_USERNAME} && -n ${KAFKA_AUTH_PASSWORD} ]]; then
 else
   prepare_unsecured_config_files
 fi
+# kafkactl >=5.18 stores the active context in a dedicated file.
+cat > /cruise-control/current-context.yml << EOL
+current-context: default
+EOL
 enrich_kafkactl_yml_with_ssl_configs
 
 
@@ -169,6 +171,8 @@ for VAR in `env`; do
 done
 
 if [[ "${EXTERNAL_KAFKA_ENABLED}" == "false" ]]; then
+  # Some static Go binaries need USER set when running under numeric UID.
+  export USER="${USER:-kafka}"
   kafkactl create topic __CruiseControlMetrics --partitions=-1 --replication-factor=-1
 fi
 

--- a/docker-cruise-control/docker/docker-entrypoint.sh
+++ b/docker-cruise-control/docker/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086,SC2223,SC2034,SC2006,SC2196
 
 # Resolve security protocol.
 #

--- a/docker-cruise-control/docker/docker-entrypoint.sh
+++ b/docker-cruise-control/docker/docker-entrypoint.sh
@@ -16,16 +16,16 @@ EOL
 }
 
 function enrich_kafkactl_yml_with_ssl_configs() {
-  if [[ "${KAFKA_ENABLE_SSL}" == "true" && -f "/tls/ca.crt" ]]; then
+  if [[ "${KAFKA_ENABLE_SSL}" == "true" && -f "/cruise-control/tls/ca.crt" ]]; then
     cat >> ${KAFKA_CTL_CONFIG} << EOL
     tls:
       enabled: true
-      ca: /tls/ca.crt
+      ca: /cruise-control/tls/ca.crt
 EOL
-    if [[ -f "/tls/tls.crt" && -f "/tls/tls.key" ]]; then
+    if [[ -f "/cruise-control/tls/tls.crt" && -f "/cruise-control/tls/tls.key" ]]; then
       cat >> ${KAFKA_CTL_CONFIG} << EOL
-      cert: /tls/tls.crt
-      certKey: /tls/tls.key
+      cert: /cruise-control/tls/tls.crt
+      certKey: /cruise-control/tls/tls.key
 EOL
     fi
   fi
@@ -123,19 +123,26 @@ cat >> config/capacityConfigFile.json << EOL
 EOL
 
 if [[ "${KAFKA_ENABLE_SSL}" == "true" ]]; then
-    kafka_ca_cert_path="tls/ca.crt"
-    kafka_tls_key_path="tls/tls.key"
-    kafka_tls_cert_path="tls/tls.crt"
+    kafka_ca_cert_path="/cruise-control/tls/ca.crt"
+    kafka_tls_key_path="/cruise-control/tls/tls.key"
+    kafka_tls_cert_path="/cruise-control/tls/tls.crt"
     kafka_tls_ks_dir="tls-ks"
     mkdir -p ${kafka_tls_ks_dir}
-    if [[ -f $kafka_ca_cert_path ]]; then
+    trust_cert_path="${kafka_ca_cert_path}"
+    # Some cert-manager TLS secrets do not include ca.crt.
+    # In that case trust the mounted certificate chain from tls.crt.
+    if [[ ! -f "${trust_cert_path}" && -f "${kafka_tls_cert_path}" ]]; then
+      echo "ca.crt is not found, using tls.crt for truststore generation"
+      trust_cert_path="${kafka_tls_cert_path}"
+    fi
+    if [[ -f "${trust_cert_path}" ]]; then
     SSL_PASSWORD="changeit"
     if [[ -f $kafka_tls_key_path && -f $kafka_tls_cert_path ]]; then
       SSL_KEYSTORE_LOCATION="${kafka_tls_ks_dir}/kafka.keystore.jks"
       openssl pkcs12 -export -in $kafka_tls_cert_path -inkey $kafka_tls_key_path -out ${kafka_tls_ks_dir}/kafka.keystore.p12 -passout pass:${SSL_PASSWORD}
       keytool -importkeystore -destkeystore ${SSL_KEYSTORE_LOCATION} -deststorepass ${SSL_PASSWORD} \
         -srckeystore ${kafka_tls_ks_dir}/kafka.keystore.p12 -srcstoretype PKCS12 -srcstorepass ${SSL_PASSWORD}
-      keytool -import -trustcacerts -keystore ${SSL_KEYSTORE_LOCATION} -storepass ${SSL_PASSWORD} -noprompt -alias ca-cert -file $kafka_ca_cert_path
+      keytool -import -trustcacerts -keystore ${SSL_KEYSTORE_LOCATION} -storepass ${SSL_PASSWORD} -noprompt -alias ca-cert -file "${trust_cert_path}"
       SSL_CONFIGURATION="ssl.keystore.location = \"${SSL_KEYSTORE_LOCATION}\"\n        ssl.keystore.password = \"${SSL_PASSWORD}\"\n        ssl.key.password = \"${SSL_PASSWORD}\""
     cat >> config/cruisecontrol.properties <<EOF
 ssl.keystore.type=JKS
@@ -146,7 +153,7 @@ EOF
     fi
 
     SSL_TRUSTSTORE_LOCATION="${kafka_tls_ks_dir}/kafka.truststore.jks"
-    keytool -import -trustcacerts -keystore ${SSL_TRUSTSTORE_LOCATION} -storepass ${SSL_PASSWORD} -noprompt -alias ca -file $kafka_ca_cert_path
+    keytool -import -trustcacerts -keystore ${SSL_TRUSTSTORE_LOCATION} -storepass ${SSL_PASSWORD} -noprompt -alias ca -file "${trust_cert_path}"
     cat >> config/cruisecontrol.properties <<EOF
 ssl.truststore.type=JKS
 ssl.truststore.location=$SSL_TRUSTSTORE_LOCATION


### PR DESCRIPTION
- Removed redundant 'current-context' entries from config file generation functions.
- Added support for kafkactl version >=5.18 by creating a dedicated current-context.yml file.
- Set USER environment variable for static Go binaries when EXTERNAL_KAFKA_ENABLED is false.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
