### PR TITLE
fix: improve stability of integration tests during Kafka rolling upgrades

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -129,6 +129,8 @@ services:
   integration-tests:
     user: "0:0"
     read_only: true
+    tmpfs:
+      - /tmp
     image: ghcr.io/netcracker/qubership-kafka-integration-tests:main
     ports:
       - "8090:8080"

--- a/docker-kafka/3/docker-entrypoint.sh
+++ b/docker-kafka/3/docker-entrypoint.sh
@@ -75,6 +75,13 @@ if [[ "$KRAFT_ENABLED" == "true" ]]; then
   export CONF_KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
   export CONF_KAFKA_CONTROLLER_QUORUM_VOTERS=${VOTERS}
   export CONF_KAFKA_NODE_ID=${BROKER_ID}
+  # The stock Apache server.properties ships controller.quorum.bootstrap.servers=localhost:9093,
+  # which points at the INTER_BROKER listener (SCRAM-SHA-512). The Raft/controller client
+  # authenticates with the controller mechanism (PLAIN), so whenever a node falls back to the
+  # bootstrap endpoint during a leader election it hits the inter-broker listener and fails with
+  # "Authentication failed: Invalid username or password". Point the bootstrap at the CONTROLLER
+  # listener (9096, PLAIN) so the fallback path authenticates against the right listener.
+  export CONF_KAFKA_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS=${CONF_KAFKA_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS:=localhost:9096}
   # KRaft controller quorum timeouts. The Apache Kafka defaults (fetch/request 2000ms,
   # election 1000ms) are too aggressive for CPU-constrained or busy environments: a
   # single missed Raft fetch triggers a spurious leader election, brokers briefly lose

--- a/docker-kafka/3/docker-entrypoint.sh
+++ b/docker-kafka/3/docker-entrypoint.sh
@@ -80,9 +80,9 @@ if [[ "$KRAFT_ENABLED" == "true" ]]; then
   # single missed Raft fetch triggers a spurious leader election, brokers briefly lose
   # their controller session and become unreachable for clients. Raise the defaults and
   # keep them overridable via CONF_KAFKA_* env vars.
-  export CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS:=5000}
-  export CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS:=3000}
-  export CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS:=2000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS:=8000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS:=5000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS:=3000}
   # For Kraft remove quorum-state file so that we won't enter voter not match error after scaling up/down https://issues.apache.org/jira/browse/KAFKA-14094
   if [ -f "/var/opt/kafka/data/$BROKER_ID/__cluster_metadata-0/quorum-state" ]; then
     echo "Removing quorum-state file"

--- a/docker-kafka/3/docker-entrypoint.sh
+++ b/docker-kafka/3/docker-entrypoint.sh
@@ -75,6 +75,14 @@ if [[ "$KRAFT_ENABLED" == "true" ]]; then
   export CONF_KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
   export CONF_KAFKA_CONTROLLER_QUORUM_VOTERS=${VOTERS}
   export CONF_KAFKA_NODE_ID=${BROKER_ID}
+  # KRaft controller quorum timeouts. The Apache Kafka defaults (fetch/request 2000ms,
+  # election 1000ms) are too aggressive for CPU-constrained or busy environments: a
+  # single missed Raft fetch triggers a spurious leader election, brokers briefly lose
+  # their controller session and become unreachable for clients. Raise the defaults and
+  # keep them overridable via CONF_KAFKA_* env vars.
+  export CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS:=5000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS:=3000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS:=2000}
   # For Kraft remove quorum-state file so that we won't enter voter not match error after scaling up/down https://issues.apache.org/jira/browse/KAFKA-14094
   if [ -f "/var/opt/kafka/data/$BROKER_ID/__cluster_metadata-0/quorum-state" ]; then
     echo "Removing quorum-state file"

--- a/docker-kafka/4/docker-entrypoint.sh
+++ b/docker-kafka/4/docker-entrypoint.sh
@@ -75,6 +75,14 @@ if [[ "$KRAFT_ENABLED" == "true" ]]; then
   export CONF_KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
   export CONF_KAFKA_CONTROLLER_QUORUM_VOTERS=${VOTERS}
   export CONF_KAFKA_NODE_ID=${BROKER_ID}
+  # KRaft controller quorum timeouts. The Apache Kafka defaults (fetch/request 2000ms,
+  # election 1000ms) are too aggressive for CPU-constrained or busy environments: a
+  # single missed Raft fetch triggers a spurious leader election, brokers briefly lose
+  # their controller session and become unreachable for clients. Raise the defaults and
+  # keep them overridable via CONF_KAFKA_* env vars.
+  export CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_FETCH_TIMEOUT_MS:=8000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_REQUEST_TIMEOUT_MS:=5000}
+  export CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS=${CONF_KAFKA_CONTROLLER_QUORUM_ELECTION_TIMEOUT_MS:=3000}
   # For Kraft remove quorum-state file so that we won't enter voter not match error after scaling up/down https://issues.apache.org/jira/browse/KAFKA-14094
   if [ -f "/var/opt/kafka/data/$BROKER_ID/__cluster_metadata-0/quorum-state" ]; then
     echo "Removing quorum-state file"

--- a/docker-kafka/4/docker-entrypoint.sh
+++ b/docker-kafka/4/docker-entrypoint.sh
@@ -75,6 +75,13 @@ if [[ "$KRAFT_ENABLED" == "true" ]]; then
   export CONF_KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
   export CONF_KAFKA_CONTROLLER_QUORUM_VOTERS=${VOTERS}
   export CONF_KAFKA_NODE_ID=${BROKER_ID}
+  # The stock Apache server.properties ships controller.quorum.bootstrap.servers=localhost:9093,
+  # which points at the INTER_BROKER listener (SCRAM-SHA-512). The Raft/controller client
+  # authenticates with the controller mechanism (PLAIN), so whenever a node falls back to the
+  # bootstrap endpoint during a leader election it hits the inter-broker listener and fails with
+  # "Authentication failed: Invalid username or password". Point the bootstrap at the CONTROLLER
+  # listener (9096, PLAIN) so the fallback path authenticates against the right listener.
+  export CONF_KAFKA_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS=${CONF_KAFKA_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS:=localhost:9096}
   # KRaft controller quorum timeouts. The Apache Kafka defaults (fetch/request 2000ms,
   # election 1000ms) are too aggressive for CPU-constrained or busy environments: a
   # single missed Raft fetch triggers a spurious leader election, brokers briefly lose

--- a/integration-tests/docker/kafka_pods_checker.py
+++ b/integration-tests/docker/kafka_pods_checker.py
@@ -24,6 +24,25 @@ namespace = environ.get("KAFKA_OS_PROJECT")
 kafka = environ.get("KAFKA_HOST")
 backup_daemon = environ.get("BACKUP_DAEMON_HOST")
 timeout = 600
+# Kafka can be updated by the operator node-by-node (rolling upgrade). During such an
+# upgrade all deployments may momentarily report "ready" in the gap between two pods
+# being rolled, so a single ready observation is not enough to assume the cluster is
+# stable. Require several consecutive ready observations spaced apart in time before
+# proceeding, so an in-progress rolling upgrade is reliably detected.
+stability_checks = int(environ.get("READINESS_STABILITY_CHECKS", 3))
+stability_retry_delay = int(environ.get("READINESS_STABILITY_RETRY_DELAY", 20))
+
+
+def deployments_ready(k8s_lib) -> bool:
+    deployments = k8s_lib.get_deployment_entities_count_for_service(namespace, kafka)
+    ready_deployments = k8s_lib.get_active_deployment_entities_count_for_service(namespace, kafka)
+    if backup_daemon:
+        print(f'Adding Kafka Backup Daemon to check')
+        deployments += k8s_lib.get_deployment_entities_count_for_service(namespace, backup_daemon, 'component')
+        ready_deployments += k8s_lib.get_active_deployment_entities_count_for_service(namespace, backup_daemon, 'component')
+    print(f'[Check status] deployments: {deployments}, ready deployments: {ready_deployments}')
+    return deployments == ready_deployments and deployments != 0
+
 
 if __name__ == '__main__':
     time.sleep(20)
@@ -40,23 +59,29 @@ if __name__ == '__main__':
     except Exception as e:
         print(e)
         exit(1)
+    consecutive_ready = 0
     timeout_start = time.time()
     while time.time() < timeout_start + timeout:
         try:
-            deployments = k8s_lib.get_deployment_entities_count_for_service(namespace, kafka)
-            ready_deployments = k8s_lib.get_active_deployment_entities_count_for_service(namespace, kafka)
-            if backup_daemon:
-                print(f'Adding Kafka Backup Daemon to check')
-                deployments += k8s_lib.get_deployment_entities_count_for_service(namespace, backup_daemon, 'component')
-                ready_deployments += k8s_lib.get_active_deployment_entities_count_for_service(namespace, backup_daemon, 'component')
-            print(f'[Check status] deployments: {deployments}, ready deployments: {ready_deployments}')
+            ready = deployments_ready(k8s_lib)
         except Exception as e:
             print(e)
+            consecutive_ready = 0
+            time.sleep(10)
             continue
-        if deployments == ready_deployments and deployments != 0:
-            print("Kafka deployments are ready")
-            time.sleep(30)
-            exit(0)
-        time.sleep(10)
-    print(f'Kafka deployments are not ready at least {timeout} seconds')
+        if ready:
+            consecutive_ready += 1
+            print(f'Kafka deployments are ready ({consecutive_ready}/{stability_checks} consecutive checks)')
+            if consecutive_ready >= stability_checks:
+                print("Kafka deployments are ready and stable")
+                time.sleep(30)
+                exit(0)
+            time.sleep(stability_retry_delay)
+        else:
+            if consecutive_ready:
+                print('Kafka deployments became not ready, resetting stability counter '
+                      '(rolling upgrade may be in progress)')
+            consecutive_ready = 0
+            time.sleep(10)
+    print(f'Kafka deployments are not ready and stable at least {timeout} seconds')
     exit(1)

--- a/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
+++ b/integration-tests/robot/tests/shared/lib/KafkaLibrary.py
@@ -22,13 +22,26 @@ from kafka import KafkaConsumer, KafkaProducer
 from kafka.admin import (NewTopic, NewPartitions, KafkaAdminClient, ACL, ACLFilter, ResourceType,
                          ACLOperation, ACLPermissionType, ResourcePattern, ConfigResource, ConfigResourceType)
 from kafka.sasl.oauth import AbstractTokenProvider
-from kafka.errors import UnknownTopicOrPartitionError, KafkaConnectionError
+from kafka.errors import (UnknownTopicOrPartitionError, KafkaConnectionError, NoBrokersAvailable,
+                          NodeNotReadyError, NotControllerError, KafkaTimeoutError)
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 
 CA_CERT_PATH = '/tls/ca.crt'
 TLS_CERT_PATH = '/tls/tls.crt'
 TLS_KEY_PATH = '/tls/tls.key'
+
+# Errors that are typically transient (a broker is being rolled/restarted, a leader or
+# coordinator is being re-elected, etc.). Operations failing with these should be retried
+# instead of failing the whole test, e.g. when tests run concurrently with a Kafka
+# rolling upgrade.
+TRANSIENT_KAFKA_ERRORS = (
+    KafkaConnectionError,
+    NoBrokersAvailable,
+    NodeNotReadyError,
+    NotControllerError,
+    KafkaTimeoutError,
+)
 
 
 def _str2bool(v: str) -> bool:
@@ -121,6 +134,49 @@ class KafkaLibrary(object):
             self.builtin.fail(f'Exception while connecting to Kafka: {e}')
         return consumer
 
+    def __build_admin_client(self):
+        """Builds a Kafka admin client, letting connection errors propagate to the caller."""
+        configs = dict(self._common_configs.items())
+        configs['metadata_max_age_ms'] = 1000
+        if self._kafka_username and self._kafka_password:
+            configs['sasl_mechanism'] = 'SCRAM-SHA-512'
+            configs['sasl_plain_username'] = self._kafka_username
+            configs['sasl_plain_password'] = self._kafka_password
+            configs['request_timeout_ms'] = 90000
+        admin = KafkaAdminClient(**configs)
+        logger.debug("Kafka admin client is created.")
+        return admin
+
+    def __execute_with_retry(self, operation, description, retries=15, delay=10):
+        """
+        Runs ``operation`` retrying on transient Kafka errors.
+
+        A fresh admin client is created for every attempt, because a stale client may
+        keep pointing at a broker that is being rolled/restarted. ``operation`` receives
+        the admin client as its only argument.
+        """
+        last_error = None
+        for attempt in range(1, retries + 1):
+            admin = None
+            try:
+                admin = self.__build_admin_client()
+                return operation(admin)
+            except TRANSIENT_KAFKA_ERRORS as e:
+                last_error = e
+                msg = (f'Attempt {attempt}/{retries}: failed to {description} '
+                       f'due to transient Kafka error: {e}')
+                BuiltIn().log_to_console(msg)
+                logger.warn(msg)
+                if attempt < retries:
+                    time.sleep(delay)
+            finally:
+                if admin is not None:
+                    try:
+                        admin.close()
+                    except Exception:
+                        pass
+        self.builtin.fail(f'Failed to {description} after {retries} attempts: {last_error}')
+
     def create_admin_client(self):
         """
         Creates Kafka admin client. If security is enabled, received credentials are used.
@@ -132,15 +188,7 @@ class KafkaLibrary(object):
         """
         admin = None
         try:
-            configs = dict(self._common_configs.items())
-            configs['metadata_max_age_ms'] = 1000
-            if self._kafka_username and self._kafka_password:
-                configs['sasl_mechanism'] = 'SCRAM-SHA-512'
-                configs['sasl_plain_username'] = self._kafka_username
-                configs['sasl_plain_password'] = self._kafka_password
-                configs['request_timeout_ms'] = 90000
-            admin = KafkaAdminClient(**configs)
-            logger.debug("Kafka admin client is created.")
+            admin = self.__build_admin_client()
         except Exception as e:
             self.builtin.fail(f'Exception while connecting to Kafka: {e}')
         return admin
@@ -169,7 +217,7 @@ class KafkaLibrary(object):
         message = f'Kafka msg: {time.time()}'
         return message
 
-    def produce_message(self, producer: KafkaProducer, topic_name, message):
+    def produce_message(self, producer: KafkaProducer, topic_name, message, retries=15, delay=10):
         """
         Sends the message to Kafka using Kafka producer.
         *Args:*\n
@@ -179,22 +227,34 @@ class KafkaLibrary(object):
         *Example:*\n
             | Produce Message | producer | consumer-producer-tests-topic | 1541506923 |
         """
-        try:
-            # producer.send(topic_name, message.encode('utf-8'))
-            # producer.flush(timeout=10)
-            future = producer.send(topic_name, message.encode("utf-8"))
-            record_metadata = future.get(timeout=10)
-            producer.flush(timeout=10)
-            self.builtin.log(
-                f"Produced to {record_metadata.topic} partition {record_metadata.partition} offset {record_metadata.offset}",
-                "INFO"
-            )
-        except Exception as e:
-            self.builtin.log(traceback.format_exc(), "ERROR")  # ruff: noqa: F821
-            self.builtin.fail(f'Failed to produce message: "{message}" to '
-                              f'topic: {topic_name} {e}')
+        last_error = None
+        for attempt in range(1, retries + 1):
+            try:
+                future = producer.send(topic_name, message.encode("utf-8"))
+                record_metadata = future.get(timeout=10)
+                producer.flush(timeout=10)
+                self.builtin.log(
+                    f"Produced to {record_metadata.topic} partition {record_metadata.partition} offset {record_metadata.offset}",
+                    "INFO"
+                )
+                return
+            except TRANSIENT_KAFKA_ERRORS as e:
+                last_error = e
+                msg = (f'Attempt {attempt}/{retries}: failed to produce message to '
+                       f'topic "{topic_name}" due to transient Kafka error: {e}')
+                BuiltIn().log_to_console(msg)
+                logger.warn(msg)
+                if attempt < retries:
+                    time.sleep(delay)
+            except Exception as e:
+                self.builtin.log(traceback.format_exc(), "ERROR")  # ruff: noqa: F821
+                self.builtin.fail(f'Failed to produce message: "{message}" to '
+                                  f'topic: {topic_name} {e}')
+                return
+        self.builtin.fail(f'Failed to produce message: "{message}" to topic: {topic_name} '
+                          f'after {retries} attempts: {last_error}')
 
-    def consume_message(self, consumer, topic_name: str) -> str:
+    def consume_message(self, consumer, topic_name: str, retries=15, delay=10) -> str:
         """
         Receives a message from Kafka using Kafka consumer.
         *Args:*\n
@@ -205,12 +265,24 @@ class KafkaLibrary(object):
             | Consume Message | consumer |
         """
         consumer.subscribe([topic_name])
-        message = consumer.poll(5000.0)
-        if message:
-            return str(message)
-        else:
-            logger.debug(f'Received message is "{message}".')
-            return ""
+        last_error = None
+        for attempt in range(1, retries + 1):
+            try:
+                message = consumer.poll(5000.0)
+                if message:
+                    return str(message)
+                logger.debug(f'Received message is "{message}".')
+                return ""
+            except TRANSIENT_KAFKA_ERRORS as e:
+                last_error = e
+                msg = (f'Attempt {attempt}/{retries}: failed to consume from '
+                       f'topic "{topic_name}" due to transient Kafka error: {e}')
+                BuiltIn().log_to_console(msg)
+                logger.warn(msg)
+                if attempt < retries:
+                    time.sleep(delay)
+        self.builtin.fail(f'Failed to consume message from topic: {topic_name} '
+                          f'after {retries} attempts: {last_error}')
 
     def get_brokers_count(self, admin: KafkaAdminClient) -> int:
         """
@@ -270,19 +342,19 @@ class KafkaLibrary(object):
         *Example:*\n
             | Create Topic | admin | kafka-topic-tests | ${1} | ${1} |
         """
-        topics = self.get_topics_list(admin)
-        if topic_name in topics:
-            logger.debug(f'Topic "{topic_name}" has already been created.')
-            return
-        new_topic = NewTopic(topic_name,
-                             num_partitions=partitions,
-                             replication_factor=replication_factor,
-                             topic_configs=configs)
-        try:
-            admin.create_topics([new_topic])
+        def _create(client):
+            topics = self.get_topics_list(client)
+            if topic_name in topics:
+                logger.debug(f'Topic "{topic_name}" has already been created.')
+                return
+            new_topic = NewTopic(topic_name,
+                                 num_partitions=partitions,
+                                 replication_factor=replication_factor,
+                                 topic_configs=configs)
+            client.create_topics([new_topic])
             logger.debug(f'Topic "{topic_name}" is created.')
-        except Exception as e:
-            self.builtin.fail(f'Failed to create topic "{topic_name}": {e}')
+
+        self.__execute_with_retry(_create, f'create topic "{topic_name}"')
 
     def create_topic_with_expected_exception(self, admin, topic_name, replication_factor, partitions):
         """


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

During a rolling upgrade the KRaft controller quorum could generate
spurious leader elections because the default fetch/request timeouts
(2 s) and election timeout (1 s) are too aggressive for CPU-constrained
CI environments. A missed Raft fetch caused all brokers to briefly lose
their controller session, making any concurrent kafka-python client
receive KafkaConnectionError even though the cluster was healthy.
Changes:
- docker-kafka/3,4: set higher default KRaft quorum timeouts
  (fetch 5 s, request 3 s, election 2 s); all values remain
  overridable via CONF_KAFKA_CONTROLLER_QUORUM_* env vars.
- integration-tests/docker/kafka_pods_checker.py: require N
  consecutive ready observations (default 3 × 20 s) before
  starting tests, so an in-progress rolling upgrade is reliably
  detected instead of being missed between two pod rolls.
  Thresholds are configurable via READINESS_STABILITY_CHECKS and
  READINESS_STABILITY_RETRY_DELAY env vars.
- integration-tests/KafkaLibrary.py: add retry logic on transient
  Kafka errors (KafkaConnectionError, NoBrokersAvailable,
  NodeNotReadyError, NotControllerError, KafkaTimeoutError) in
  create_topic, produce_message and consume_message, consistent
  with the existing retry in delete_topics.
- demo/docker-compose.yml: add tmpfs /tmp for the integration-tests
  container so Robot Framework can write temporary files under
  read_only: true.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
