### PR TITLE
fix: http routes enable by default

### DIFF
--- a/operator/charts/helm/kafka-service/templates/_helpers.tpl
+++ b/operator/charts/helm/kafka-service/templates/_helpers.tpl
@@ -733,12 +733,16 @@ Ingress host for Cruise Control
 {{- $root := index . 0 -}}
 {{- $refs := index . 1 | default list -}}
 {{- if and $root.Values.GATEWAY_SYSTEM_NAME $root.Values.GATEWAY_SYSTEM_NAMESPACE }}
-- name: {{ $root.Values.GATEWAY_SYSTEM_NAME }}
+- group: gateway.networking.k8s.io
+  kind: Gateway
+  name: {{ $root.Values.GATEWAY_SYSTEM_NAME }}
   namespace: {{ $root.Values.GATEWAY_SYSTEM_NAMESPACE }}
   port: 443
 {{- else if gt (len $refs) 0 }}
 {{- range $refs }}
-- name: {{ .name }}
+- group: gateway.networking.k8s.io
+  kind: Gateway
+  name: {{ .name }}
   namespace: {{ .namespace }}
   port: 443
 {{- end }}

--- a/operator/charts/helm/kafka-service/templates/akhq-httproute.yaml
+++ b/operator/charts/helm/kafka-service/templates/akhq-httproute.yaml
@@ -27,7 +27,7 @@ spec:
             value: /
       backendRefs:
         - name: akhq
-          group: ''
+          group: ""
           kind: Service
           port: 8080
           weight: 1

--- a/operator/charts/helm/kafka-service/templates/akhq-httproute.yaml
+++ b/operator/charts/helm/kafka-service/templates/akhq-httproute.yaml
@@ -11,7 +11,7 @@ metadata:
     route.openshift.io/termination: edge
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.akhq.envoyGateway.parentRefs) | nindent 2 }}
+  {{- include "gateway.parentRefs" (list . .Values.akhq.envoyGateway.parentRefs) | nindent 4 }}
 
   hostnames:
   {{- if .Values.akhq.envoyGateway.host }}
@@ -27,7 +27,10 @@ spec:
             value: /
       backendRefs:
         - name: akhq
+          group: ''
+          kind: Service
           port: 8080
+          weight: 1
 
 {{- end }}
 {{- end }}

--- a/operator/charts/helm/kafka-service/templates/cruise-control/cc_httproute.yaml
+++ b/operator/charts/helm/kafka-service/templates/cruise-control/cc_httproute.yaml
@@ -12,7 +12,7 @@ metadata:
     route.openshift.io/termination: edge
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.cruiseControl.envoyGateway.parentRefs) | nindent 2 }}
+  {{- include "gateway.parentRefs" (list . .Values.cruiseControl.envoyGateway.parentRefs) | nindent 4 }}
 
   hostnames:
   {{- if .Values.cruiseControl.envoyGateway.host }}
@@ -28,7 +28,10 @@ spec:
             value: /
       backendRefs:
         - name: {{ template "kafka.name" . }}-cruise-control
+          group: ''
+          kind: Service
           port: 9090
+          weight: 1
 
 {{- end }}
 {{- end }}

--- a/operator/charts/helm/kafka-service/templates/cruise-control/cc_httproute.yaml
+++ b/operator/charts/helm/kafka-service/templates/cruise-control/cc_httproute.yaml
@@ -28,7 +28,7 @@ spec:
             value: /
       backendRefs:
         - name: {{ template "kafka.name" . }}-cruise-control
-          group: ''
+          group: ""
           kind: Service
           port: 9090
           weight: 1

--- a/operator/charts/helm/kafka-service/values.yaml
+++ b/operator/charts/helm/kafka-service/values.yaml
@@ -332,10 +332,12 @@ akhq:
     host: ""
     className: ""
   envoyGateway:
-    enabled: false
+    enabled: true
     host: ""
     parentRefs:
-      - name: default-external-gateway
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: default-external-gateway
         namespace: gateway-system
   ldap:
     enabled: false
@@ -727,10 +729,12 @@ cruiseControl:
   ingress:
     host: ""
   envoyGateway:
-    enabled: false
+    enabled: true
     host: ""
     parentRefs:
-      - name: default-external-gateway
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: default-external-gateway
         namespace: gateway-system
 
   prometheusServerEndpoint: ""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request updates the Helm chart templates and values for the Kafka service to improve compatibility and correctness with Kubernetes Gateway API conventions. The changes focus on explicitly specifying resource kinds and groups for gateway and service references, correcting YAML indentation, and enabling Envoy Gateway by default for both AKHQ and Cruise Control components.

**Gateway and Service Reference Improvements:**

* Updated all gateway references in template files (`_helpers.tpl`, `values.yaml`) to include explicit `group: gateway.networking.k8s.io` and `kind: Gateway` fields, ensuring compatibility with the Gateway API and avoiding ambiguity. [[1]](diffhunk://#diff-561ea28e005aeebfcae84e616067f333dd9b93519cfc50c1d48b90b6903bc645L736-R745) [[2]](diffhunk://#diff-fab616033991e6b487ca1719423aa284b36af8ea986ac9f54def428533ecbf64L335-R340) [[3]](diffhunk://#diff-fab616033991e6b487ca1719423aa284b36af8ea986ac9f54def428533ecbf64L730-R737)
* Modified backend service references in `akhq-httproute.yaml` and `cc_httproute.yaml` to include `group: ""` and `kind: Service`, making the resource type explicit for the Gateway API. Also added a `weight: 1` field for each backend reference. [[1]](diffhunk://#diff-4f5568fc3eea83fd10ba609817d8799ba2a68c2a623aaf28d94fb09ae4f11400R30-R33) [[2]](diffhunk://#diff-6fa8d67e47d52fc144a38a3a4de38cac5690bc90edc8f80eff5110ade907a514R31-R34)

**YAML Formatting and Indentation Fixes:**

* Corrected the indentation of the `parentRefs` block in both `akhq-httproute.yaml` and `cc_httproute.yaml` to ensure proper YAML structure and parsing. [[1]](diffhunk://#diff-4f5568fc3eea83fd10ba609817d8799ba2a68c2a623aaf28d94fb09ae4f11400L14-R14) [[2]](diffhunk://#diff-6fa8d67e47d52fc144a38a3a4de38cac5690bc90edc8f80eff5110ade907a514L15-R15)

**Default Configuration Changes:**

* Enabled Envoy Gateway by default for both AKHQ and Cruise Control in the `values.yaml` file, and updated their default `parentRefs` to use the new explicit gateway reference structure. [[1]](diffhunk://#diff-fab616033991e6b487ca1719423aa284b36af8ea986ac9f54def428533ecbf64L335-R340) [[2]](diffhunk://#diff-fab616033991e6b487ca1719423aa284b36af8ea986ac9f54def428533ecbf64L730-R737)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue: CPCAP-10403
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
