### PR TITLE
fix: simple Ingress without TLS

### DIFF
--- a/operator/charts/helm/kafka-service/templates/_helpers.tpl
+++ b/operator/charts/helm/kafka-service/templates/_helpers.tpl
@@ -737,14 +737,12 @@ Ingress host for Cruise Control
   kind: Gateway
   name: {{ $root.Values.GATEWAY_SYSTEM_NAME }}
   namespace: {{ $root.Values.GATEWAY_SYSTEM_NAMESPACE }}
-  port: 443
 {{- else if gt (len $refs) 0 }}
 {{- range $refs }}
 - group: gateway.networking.k8s.io
   kind: Gateway
   name: {{ .name }}
   namespace: {{ .namespace }}
-  port: 443
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In applications, you only manage HTTPRoute (and similar resources), you do not need to manage Gateway, just reference one. Note that this route will be available on all Gateway Listeners with HTTP protocol, such as on both ports 80 (without TLS) and port 443 (with TLS).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #PSUPCLCAP-4819
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
