### PR TITLE
fix: change kafka3 distro url

### DIFF
--- a/docker-kafka/3/Dockerfile
+++ b/docker-kafka/3/Dockerfile
@@ -41,7 +41,7 @@ RUN set -x \
 
 ARG KAFKA_VERSION=3.9.2
 ARG DISTRO_NAME=kafka_2.12-${KAFKA_VERSION}
-ARG KAFKA_DISTRO_URL="https://archive.apache.org/kafka/${KAFKA_VERSION}/${DISTRO_NAME}.tgz"
+ARG KAFKA_DISTRO_URL="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${DISTRO_NAME}.tgz"
 # Download Apache Kafka and install
 RUN set -x \
     && export DISTR_DIR="$(mktemp -d)" \

--- a/docker-kafka/3/Dockerfile
+++ b/docker-kafka/3/Dockerfile
@@ -41,7 +41,7 @@ RUN set -x \
 
 ARG KAFKA_VERSION=3.9.2
 ARG DISTRO_NAME=kafka_2.12-${KAFKA_VERSION}
-ARG KAFKA_DISTRO_URL="https://downloads.apache.org/kafka/${KAFKA_VERSION}/${DISTRO_NAME}.tgz"
+ARG KAFKA_DISTRO_URL="https://archive.apache.org/kafka/${KAFKA_VERSION}/${DISTRO_NAME}.tgz"
 # Download Apache Kafka and install
 RUN set -x \
     && export DISTR_DIR="$(mktemp -d)" \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

https://downloads.apache.org/kafka/ has removed 3..x.x versions
<img width="842" height="82" alt="image" src="https://github.com/user-attachments/assets/05891f93-787d-43a8-8b76-4f5abc68e7c9" />

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
