### PR TITLE
fix: Change verify timeout configuration to valid

### DIFF
--- a/.github/workflows/run_nightly_tests.yaml
+++ b/.github/workflows/run_nightly_tests.yaml
@@ -17,7 +17,8 @@ jobs:
       pipeline_branch: '9fcb2de51b4d510b52ffca883515bdb388cbc16f' # v1.14.0 renovate: depName=Netcracker/qubership-test-pipelines
       scope: 'nightly'
       allure: true
-      verify_timeout_minutes: 30
+      verify_timeout_core_minutes: 30
+      verify_timeout_serv_minutes: 30
     secrets:
       AWS_S3_ACCESS_KEY_ID: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
       AWS_S3_ACCESS_KEY_SECRET: ${{secrets.AWS_S3_ACCESS_KEY_SECRET}}

--- a/.github/workflows/run_nightly_tests.yaml
+++ b/.github/workflows/run_nightly_tests.yaml
@@ -6,8 +6,7 @@ permissions:
   actions: read
 
 on:
-  schedule:
-    - cron: '0 1 * * *'
+  push
 
 jobs:
   Nightly-Kafka-Pipeline:

--- a/.github/workflows/run_nightly_tests.yaml
+++ b/.github/workflows/run_nightly_tests.yaml
@@ -6,7 +6,8 @@ permissions:
   actions: read
 
 on:
-  push
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   Nightly-Kafka-Pipeline:


### PR DESCRIPTION
Split verify timeout into core and service specific values.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed workflow error
[Invalid workflow file: .github/workflows/run_nightly_tests.yaml#L20](https://github.com/Netcracker/qubership-kafka/actions/runs/29668841284/workflow)
The workflow is not valid. .github/workflows/run_nightly_tests.yaml (Line: 20, Col: 31): Invalid input, verify_timeout_minutes is not defined in the referenced workflow.
https://github.com/Netcracker/qubership-kafka/actions/runs/29668841284

Test run:
https://github.com/Netcracker/qubership-kafka/actions/runs/29787194357

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
